### PR TITLE
Fix decimal and negative numbers plural in French

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -579,9 +579,9 @@ export default {
             sample: 2
         }],
         nplurals: 2,
-        pluralsText: 'nplurals = 2; plural = (n > 1)',
+        pluralsText: 'nplurals = 2; plural = (n <= -2 || n >= 2)',
         pluralsFunc: function(n) {
-            return (n > 1);
+            return n <= -2 || n >= 2;
         }
     },
     fur: {


### PR DESCRIPTION
In French (and many Latin-like languages),
0 is singular
0.5 is singular
-1 is singular
1.5 is singular
-4 is plural

So this PR fixes all those broken cases

If `n` is supposed to be integer and positive, please provide some advice about how to handle properly decimal number, such as:

| Language | 1 | 1.5 | 2 |
|---|---|---|---|
| English | liter | liter`s` | liter`s` |
| French | litre | litre | litre`s` |